### PR TITLE
API-147: Helper search resources

### DIFF
--- a/spec/Search/SearchBuilderSpec.php
+++ b/spec/Search/SearchBuilderSpec.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace spec\Akeneo\Pim\Builder;
+
+use Akeneo\Pim\Search\Operator;
+use Akeneo\Pim\Search\SearchBuilder;
+use PhpSpec\ObjectBehavior;
+
+class SearchBuilderSpec  extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(SearchBuilder::class);
+    }
+
+    function it_builds_a_search_with_a_single_filter_without_options()
+    {
+        $this->addFilter('foo' , Operator::EQUAL, 'bar')->shouldReturn($this);
+
+        $this->getFilters()->shouldReturn(
+            [
+                'foo'=> [
+                    [
+                        'operator' => Operator::EQUAL,
+                        'value'    => 'bar',
+                    ]
+                ]
+            ]
+        );
+    }
+
+    function it_builds_a_search_with_a_single_filter_without_value_nor_option()
+    {
+        $this->addFilter('family' , Operator::EMPTY)->shouldReturn($this);
+
+        $this->getFilters()->shouldReturn(
+            [
+                'family'=> [
+                    [
+                        'operator' => Operator::EMPTY,
+                    ]
+                ]
+            ]
+        );
+    }
+
+    function it_builds_a_search_with_a_single_filter_with_some_options()
+    {
+        $this
+            ->addFilter('foo' , Operator::EQUAL, 'bar', ['scope' => 'chan1', 'locale' => 'en_US'])
+            ->shouldReturn($this);
+
+        $this->getFilters()->shouldReturn(
+            [
+                'foo'=> [
+                    [
+                        'operator' => Operator::EQUAL,
+                        'value'    => 'bar',
+                        'scope'    => 'chan1',
+                        'locale'   => 'en_US',
+                    ]
+                ]
+            ]
+        );
+    }
+
+    function it_builds_a_search_with_several_filters_on_the_same_property()
+    {
+        $this->addFilter('foo' , Operator::EQUAL, 'bar')->shouldReturn($this);
+        $this->addFilter('foo' , Operator::NOT_EQUAL, 42)->shouldReturn($this);
+
+        $this->getFilters()->shouldReturn(
+            [
+                'foo'=> [
+                    [
+                        'operator' => Operator::EQUAL,
+                        'value'    => 'bar',
+                    ],
+                    [
+                        'operator' => Operator::NOT_EQUAL,
+                        'value'    => 42,
+                    ],
+                ]
+            ]
+        );
+    }
+
+    function it_builds_a_search_with_filters_on_several_properties()
+    {
+        $this->addFilter('foo' , Operator::EQUAL, 'bar')->shouldReturn($this);
+        $this->addFilter('family' , Operator::IN, ['tshirts', 'mugs'])->shouldReturn($this);
+
+        $this->getFilters()->shouldReturn(
+            [
+                'foo'=> [
+                    [
+                        'operator' => Operator::EQUAL,
+                        'value'    => 'bar',
+                    ],
+                ],
+                'family' => [
+                    [
+                        'operator' => Operator::IN,
+                        'value'    => ['tshirts', 'mugs']
+                    ]
+                ]
+            ]
+        );
+    }
+}

--- a/src/Search/Operator.php
+++ b/src/Search/Operator.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Akeneo\Pim\Search;
+
+/**
+ * This class contains the list of operators to use in filters to search resources.
+ *
+ * @author    Laurent Petard <laurent.petard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class Operator
+{
+    const EQUAL = '=';
+    const NOT_EQUAL = '!=';
+    const GREATER_THAN = '>';
+    const GREATER_THAN_OR_EQUAL = '>=';
+    const LOWER_THAN = '<';
+    const LOWER_THAN_OR_EQUAL = '<=';
+    const IN = 'IN';
+    const NOT_IN = 'NOT IN';
+    const IN_OR_UNCLASSIFIED = 'IN OR UNCLASSIFIED';
+    const IN_CHILDREN = 'IN CHILDREN';
+    const NOT_IN_CHILDREN = 'NOT IN CHILDREN';
+    const UNCLASSIFIED = 'UNCLASSIFIED';
+    const GREATER_THAN_ON_ALL_LOCALES = 'GREATER THAN ON ALL LOCALES';
+    const GREATER_OR_EQUALS_THAN_ON_ALL_LOCALES = 'GREATER OR EQUALS THAN ON ALL LOCALES';
+    const LOWER_THAN_ON_ALL_LOCALES = 'LOWER THAN ON ALL LOCALES';
+    const LOWER_OR_EQUALS_THAN_ON_ALL_LOCALES = 'LOWER OR EQUALS THAN ON ALL LOCALES';
+    const EMPTY = 'EMPTY';
+    const NOT_EMPTY = 'NOT EMPTY';
+    const BETWEEN = 'BETWEEN';
+    const NOT_BETWEEN = 'NOT BETWEEN';
+    const SINCE_LAST_N_DAYS = 'SINCE LAST N DAYS';
+    const STARTS_WITH = 'STARTS WITH';
+    const ENDS_WITH = 'ENDS WITH';
+    const CONTAINS = 'CONTAINS';
+    const DOES_NOT_CONTAIN = 'DOES NOT CONTAIN';
+}

--- a/src/Search/SearchBuilder.php
+++ b/src/Search/SearchBuilder.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Akeneo\Pim\Search;
+
+/**
+ * Helper to build search filters to apply when requesting a list of resources.
+ * After setting your filters, you have to pass them to the query parameter "search".
+ *
+ * @author    Laurent Petard <laurent.petard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class SearchBuilder
+{
+    /** @var array */
+    protected $filters = [];
+
+    /**
+     * Add a filter on a property with an operator and a value.
+     *
+     * @see https://api.akeneo.com/documentation/filter.html for the list of properties and operators.
+     *
+     * @param string      $property property on which the filter will be applied.
+     * @param string      $operator operator of the filter.
+     * @param mixed|null  $value    value of the filter. Should not be defined for certain specifics operators.
+     * @param array       $options  optionals parameters to apply to the filter (as scope or locale).
+     *
+     * @return SearchBuilder
+     */
+    public function addFilter($property, $operator, $value = null, array $options = [])
+    {
+        $filter = ['operator'=> $operator];
+
+        if (null !== $value) {
+            $filter['value'] = $value;
+        }
+
+        $this->filters[$property][] = $filter + $options;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getFilters()
+    {
+        return $this->filters;
+    }
+}


### PR DESCRIPTION
The namespace and class name have to be discussed. I'm not satisfied with those, but have difficulties to find better.

I've used a optional parameter `$options` to handle the scope and the locales. It's at least not perfect, but this allows to manage specifics case like `locale` which can be plural for filter on completeness, and for potentials future cases.

It's seems to be the best compromise between user  experience and less coupling with the API

Exemple of usage : 

```
$search = new \Akeneo\Pim\Search\SearchBuilder();
$search
    ->addFilter('family' , 'IN', ['tshirts'])
    ->addFilter('completeness' , '>', 50, ['scope' => 'ecommerce'])
    ->addFilter('light_metering' , '=', 'test1', ['locale' => 'en_US'])
;

$response = $api->listPerPage(10, false, ['search' => $search->toArray()]);
```

