### PR TITLE
Initialize integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ vendor
 composer.lock
 /phpspec.yml
 .php_cs.cache
+etc/parameters.yml
+phpunit.xml

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
   ],
   "autoload": {
     "psr-4": {
-      "Akeneo\\Pim\\": "src/"
+      "Akeneo\\Pim\\": "src/",
+      "Akeneo\\Pim\\tests\\": "tests/"
     }
   },
   "require": {
@@ -27,7 +28,8 @@
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^v2.3",
     "phpunit/phpunit": "5.7.*",
-    "phpspec/phpspec": "3.2.*"
+    "phpspec/phpspec": "3.2.*",
+    "symfony/yaml": "^3.3"
   },
   "config": {
     "bin-dir": "bin"

--- a/etc/parameters.yml.dist
+++ b/etc/parameters.yml.dist
@@ -1,0 +1,9 @@
+api:
+    baseUri: 'http://akeneo-pim.local'
+    credentials:
+        username: 'admin'
+        password: 'admin'
+
+pim:
+    install_path: '/home/docker/pim'
+    is_docker: false

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+     bootstrap="vendor/autoload.php"
+     backupGlobals="false"
+     backupStaticAttributes="false"
+     colors="true"
+     convertErrorsToExceptions="true"
+     convertNoticesToExceptions="true"
+     convertWarningsToExceptions="true"
+     processIsolation="true"
+     stopOnFailure="false"
+     syntaxCheck="false">
+
+    <testsuite>
+        <directory suffix="Integration.php">tests/</directory>
+    </testsuite>
+</phpunit>

--- a/tests/Api/ApiTestCase.php
+++ b/tests/Api/ApiTestCase.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Akeneo\Pim\tests\Api;
+
+use Akeneo\Pim\Client\AkeneoPimClientBuilder;
+use Akeneo\Pim\Client\AkeneoPimClientInterface;
+use Akeneo\Pim\Routing\UriGenerator;
+use Akeneo\Pim\Routing\UriGeneratorInterface;
+use Akeneo\Pim\tests\LocalCredentialGenerator;
+use Akeneo\Pim\tests\LocalDatabaseInstaller;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * @author    Laurent Petard <laurent.petard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+abstract class ApiTestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $config = $this->getConfiguration();
+
+        $installer = new LocalDatabaseInstaller();
+        $installer->install($config['pim']['install_path']);
+    }
+
+    /**
+     * @return AkeneoPimClientInterface
+     */
+    protected function createClient()
+    {
+        $config = $this->getConfiguration();
+        $generator = new LocalCredentialGenerator();
+        $credentials = $generator->generate($config['pim']['install_path']);
+        $clientBuilder = new AkeneoPimClientBuilder($config['api']['baseUri']);
+
+        return $clientBuilder->buildAuthenticatedByPassword(
+            $credentials['client_id'],
+            $credentials['secret'],
+            $config['api']['credentials']['username'],
+            $config['api']['credentials']['password']
+        );
+    }
+
+    /**
+     * @return UriGeneratorInterface
+     */
+    protected function getUriGenerator()
+    {
+        $config = $this->getConfiguration();
+
+        return new UriGenerator($config['api']['baseUri']);
+    }
+
+    /**
+     * @throws \RuntimeException
+     *
+     * @return array
+     */
+    protected function getConfiguration()
+    {
+        $configFile = realpath(dirname(__FILE__)).'/../../etc/parameters.yml';
+        if (!is_file($configFile)) {
+            throw new \RuntimeException('The configuration file parameters.yml is missing');
+        }
+
+        $config = Yaml::parse(file_get_contents($configFile));
+
+        return $config;
+    }
+
+    /**
+     * Assert that all the expected data of a content of a resource are the same in an actual one.
+     * The actual content can contains more data than the expected one.
+     *
+     * @param array $expectedContent
+     * @param array $actualContent
+     */
+    public function assertSameContent(array $expectedContent, array $actualContent)
+    {
+        $differences = $this->computeArrayDiff($expectedContent, $actualContent);
+
+        if (! empty($differences)) {
+            $this->fail(
+                'Failed asserting that the content has the expected body.'
+                .PHP_EOL
+                .'Differences between expected and actual content :'
+                .PHP_EOL
+                .var_export($differences, true)
+            );
+        }
+    }
+
+    /**
+     * @param array $expectedValues
+     * @param array $actualValues
+     *
+     * @return array
+     */
+    protected function computeArrayDiff(array $expectedValues, array $actualValues)
+    {
+        $differences = [];
+
+        foreach ($expectedValues as $key => $expectedValue) {
+            if (!array_key_exists($key, $actualValues)) {
+                $differences[$key] = $expectedValue;
+            } elseif (is_array($expectedValue)) {
+                if (is_array($actualValues[$key])) {
+                    $embeddedDifferences = $this->computeArrayDiff($expectedValue, $actualValues[$key]);
+                    if (!empty($embeddedDifferences)) {
+                        $differences[$key] = $embeddedDifferences;
+                    }
+                } else {
+                    $differences[$key] = $expectedValue;
+                }
+            } elseif ($expectedValue !== $actualValues[$key]) {
+                $differences[$key] = $expectedValue;
+            }
+        }
+
+        return $differences;
+    }
+}

--- a/tests/CredentialGeneratorInterface.php
+++ b/tests/CredentialGeneratorInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Akeneo\Pim\tests;
+
+/**
+ * Aims to generate the couple client id/secret on the PIM.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface CredentialGeneratorInterface
+{
+    /**
+     * Generates credentials on the PIM.
+     *
+     * @param string $path    path to Akeneo PIM application
+     * @param array  $options additional options to generate the credentials
+     *
+     * @throws \RuntimeException if an error occured during the generation process
+     *
+     * @return array credentials on the form ['client_id' => 'client', 'secret' => 'secret']
+     */
+    public function generate($path, array $options = []);
+}

--- a/tests/DatabaseInstallerInterface.php
+++ b/tests/DatabaseInstallerInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Akeneo\Pim\tests;
+
+/**
+ * Aims to install fixtures into the PIM in order to reset the database between the test.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface DatabaseInstallerInterface
+{
+    /**
+     * Install the database of the PIM.
+     *
+     * @param string $path    path to Akeneo PIM application
+     * @param array  $options additional options to install the PIM
+     *
+     * @throws \RuntimeException if an error occured during the PIM install
+     */
+    public function install($path, array $options = []);
+}

--- a/tests/LocalCredentialGenerator.php
+++ b/tests/LocalCredentialGenerator.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Akeneo\Pim\tests;
+
+/**
+ * Aims to generate the couple client/secret id on a local PIM installation.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class LocalCredentialGenerator implements CredentialGeneratorInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function generate($path, array $options = [])
+    {
+        if (!is_dir($path)) {
+            throw new \RuntimeException(sprintf('Parameter "path" is not a directory or does not exist, "%s" given.', $path));
+        }
+
+        $command = sprintf('php %s/app/console pim:oauth-server:create-client -e prod', $path);
+
+        $output = [];
+        exec(escapeshellcmd($command), $output);
+
+        if (count($output) !== 3) {
+            throw new \RuntimeException('An error occurred during the generation of the client id and secret.');
+        }
+
+        preg_match('/client_id: (.+)$/', $output[1], $client);
+        preg_match('/secret: (.+)$/', $output[2], $secret);
+
+        if (!isset($client[1]) || !isset($secret[1])) {
+            throw new \RuntimeException('An error occurred when getting client id and secret from the generation process output.');
+        }
+
+        return ['client_id' => $client[1], 'secret' => $secret[1]];
+    }
+}

--- a/tests/LocalDatabaseInstaller.php
+++ b/tests/LocalDatabaseInstaller.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Akeneo\Pim\tests;
+
+/**
+ * Aims to install fixtures on a local PIM installation.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class LocalDatabaseInstaller implements DatabaseInstallerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function install($path, array $options = [])
+    {
+        if (!is_dir($path)) {
+            throw new \RuntimeException(sprintf('Parameter "path" is not a directory or does not exist, "%s" given.', $path));
+        }
+
+        $command = sprintf('php %s/app/console pim:installer:db -e prod', $path);
+
+        $output = [];
+        exec(escapeshellcmd($command), $output, $status);
+
+        $output = implode(PHP_EOL, $output);
+
+        if (0 !== $status) {
+            throw new \RuntimeException(sprintf('An error occurred during the installation of the PIM. Output: %s', $output));
+        }
+    }
+}


### PR DESCRIPTION
For each test we need to reset the data fixtures, and we need to generate credentials (i.e. clientId and secret). This is done by executing commands console in the PIM.

I add a function to assert that a resource content is the same that another one, because it can not be done natively with PHPUnit. But don't look too much closer this function because I'm going to refactor it.