### PR TITLE
API-264: simplify HTTP exception

### DIFF
--- a/spec/Exception/HttpExceptionSpec.php
+++ b/spec/Exception/HttpExceptionSpec.php
@@ -19,18 +19,10 @@ class HttpExceptionSpec extends ObjectBehavior
         $this->shouldHaveType('Akeneo\Pim\Exception\HttpException');
     }
 
-    function it_exposes_the_response_body($response, StreamInterface $body)
-    {
-        $response->getStatusCode()->willReturn(200);
-        $response->getBody()->willReturn($body);
-        $body->getContents()->willReturn('body content');
-        $this->getResponseBody()->shouldReturn('body content');
-    }
-
     function it_exposes_the_status_code_of_the_response($response)
     {
         $response->getStatusCode()->willReturn(200);
-        $this->getStatusCode()->shouldReturn(200);
+        $this->getCode()->shouldReturn(200);
     }
 
     function it_exposes_the_response($response)

--- a/spec/Exception/UnprocessableEntityHttpExceptionSpec.php
+++ b/spec/Exception/UnprocessableEntityHttpExceptionSpec.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace spec\Akeneo\Pim\Exception;
+
+use Akeneo\Pim\Exception\UnprocessableEntityHttpException;
+use PhpSpec\ObjectBehavior;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+class UnprocessableEntityHttpExceptionSpec extends ObjectBehavior
+{
+    function let(RequestInterface $request, ResponseInterface $response)
+    {
+        $this->beConstructedWith('message', $request, $response);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(UnprocessableEntityHttpException::class);
+    }
+
+    function it_exposes_the_response_errors($response, StreamInterface $body)
+    {
+        $response->getStatusCode()->willReturn(422);
+        $response->getBody()->willReturn($body);
+        $body->getContents()->willReturn(
+            <<<JSON
+    {
+        "code": "422",
+        "message": "The response message",
+        "errors": [
+            {
+                "property": "labels",
+                "message": "The first error"
+            },
+            {
+                "property": "labels",
+                "message": "The second error"
+            }
+        ]
+    }
+JSON
+        );
+
+        $this->getResponseErrors()->shouldReturn([
+            [
+                'property' => 'labels',
+                'message'  => 'The first error',
+            ],
+            [
+                'property' => 'labels',
+                'message'  => 'The second error',
+            ]
+        ]);
+    }
+
+    function it_returns_an_empty_array_when_the_response_has_no_errors($response, StreamInterface $body)
+    {
+        $response->getStatusCode()->willReturn(422);
+        $response->getBody()->willReturn($body);
+        $body->getContents()->willReturn(
+            <<<JSON
+    {
+        "code": "422",
+    }
+JSON
+        );
+
+        $this->getResponseErrors()->shouldReturn([]);
+    }
+
+    function it_returns_an_empty_array_when_the_body_is_not_a_valid_json($response, StreamInterface $body)
+    {
+        $response->getStatusCode()->willReturn(422);
+        $response->getBody()->willReturn($body);
+        $body->getContents()->willReturn('Not a json');
+        $this->getResponseErrors()->shouldReturn([]);
+    }
+}

--- a/spec/HttpClient/HttpClientSpec.php
+++ b/spec/HttpClient/HttpClientSpec.php
@@ -8,6 +8,7 @@ use Http\Message\RequestFactory;
 use PhpSpec\ObjectBehavior;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 
 class HttpClientSpec extends ObjectBehavior
 {
@@ -51,7 +52,8 @@ class HttpClientSpec extends ObjectBehavior
         $requestFactory,
         $httpClient,
         RequestInterface $request,
-        ResponseInterface $response
+        ResponseInterface $response,
+        StreamInterface $responseBody
     ) {
         $requestFactory->createRequest(
             'POST',
@@ -63,7 +65,8 @@ class HttpClientSpec extends ObjectBehavior
         $httpClient->sendRequest($request)->willReturn($response);
 
         $response->getStatusCode()->willReturn(500);
-        $response->getReasonPhrase()->willReturn('Server error');
+        $response->getBody()->willReturn($responseBody);
+        $responseBody->getContents()->willReturn('{"code": 500, "message": "Internal error."}');
 
         $this
             ->shouldThrow(HttpException::class)

--- a/src/Exception/HttpException.php
+++ b/src/Exception/HttpException.php
@@ -53,24 +53,4 @@ class HttpException extends \RuntimeException
     {
         return $this->response;
     }
-
-    /**
-     * Returns the HTTP status code of the response.
-     *
-     * @return integer
-     */
-    public function getStatusCode()
-    {
-        return $this->response->getStatusCode();
-    }
-
-    /**
-     * Returns the body's content of the response.
-     *
-     * @return string
-     */
-    public function getResponseBody()
-    {
-        return $this->response->getBody()->getContents();
-    }
 }

--- a/src/Exception/UnprocessableEntityHttpException.php
+++ b/src/Exception/UnprocessableEntityHttpException.php
@@ -11,4 +11,15 @@ namespace Akeneo\Pim\Exception;
  */
 class UnprocessableEntityHttpException extends ClientErrorHttpException
 {
+    /**
+     * Returns the errors of the response if there are any
+     *
+     * @return array
+     */
+    public function getResponseErrors()
+    {
+        $decodedBody = json_decode($this->getResponse()->getBody()->getContents(), true);
+
+        return isset($decodedBody['errors']) ? $decodedBody['errors'] : [];
+    }
 }

--- a/src/HttpClient/HttpExceptionHandler.php
+++ b/src/HttpClient/HttpExceptionHandler.php
@@ -38,29 +38,43 @@ class HttpExceptionHandler
     public function transformResponseToException(RequestInterface $request, ResponseInterface $response)
     {
         if (400 === $response->getStatusCode()) {
-            throw new BadRequestHttpException($response->getReasonPhrase(), $request, $response);
+            throw new BadRequestHttpException($this->getResponseMessage($response), $request, $response);
         }
 
         if (401 === $response->getStatusCode()) {
-            throw new UnauthorizedHttpException($response->getReasonPhrase(), $request, $response);
+            throw new UnauthorizedHttpException($this->getResponseMessage($response), $request, $response);
         }
 
         if (404 === $response->getStatusCode()) {
-            throw new NotFoundHttpException($response->getReasonPhrase(), $request, $response);
+            throw new NotFoundHttpException($this->getResponseMessage($response), $request, $response);
         }
 
         if (422 === $response->getStatusCode()) {
-            throw new UnprocessableEntityHttpException($response->getReasonPhrase(), $request, $response);
+            throw new UnprocessableEntityHttpException($this->getResponseMessage($response), $request, $response);
         }
 
         if ($response->getStatusCode() >= 400 && $response->getStatusCode() < 500) {
-            throw new ClientErrorHttpException($response->getReasonPhrase(), $request, $response);
+            throw new ClientErrorHttpException($this->getResponseMessage($response), $request, $response);
         }
 
         if ($response->getStatusCode() >= 500 && $response->getStatusCode() < 600) {
-            throw new ServerErrorHttpException($response->getReasonPhrase(), $request, $response);
+            throw new ServerErrorHttpException($this->getResponseMessage($response), $request, $response);
         }
 
         return $response;
+    }
+
+    /**
+     * Returns the response message, or the reason phrase if there is none.
+     *
+     * @param ResponseInterface $response
+     *
+     * @return string
+     */
+    protected function getResponseMessage(ResponseInterface $response)
+    {
+        $decodedBody = json_decode($response->getBody()->getContents(), true);
+
+        return isset($decodedBody['message']) ? $decodedBody['message'] : $response->getReasonPhrase();
     }
 }


### PR DESCRIPTION
Simplifcation de nos HTTP exception. Le code HTTP est directement celui de l'exception. Le message de l'exception est le message contenu dans le json de la réponse s'il existe, et le "reason phrase" sinon.