### PR TITLE
API-266: rework upsert resource list

### DIFF
--- a/src/Api/UpsertableResourceListInterface.php
+++ b/src/Api/UpsertableResourceListInterface.php
@@ -3,6 +3,7 @@
 namespace Akeneo\Pim\Api;
 
 use Akeneo\Pim\Exception\HttpException;
+use Psr\Http\Message\StreamInterface;
 
 /**
  * API that can "upsert" a list of resources.
@@ -16,7 +17,7 @@ interface UpsertableResourceListInterface
     /**
      * Updates or creates several resources.
      *
-     * @param array|\Traversable $resources array or Traversable object containing the resources to create or update
+     * @param array|StreamInterface $resources array or StreamInterface object containing the resources to create or update
      *
      * @throws HttpException
      *

--- a/src/Client/AkeneoPimClientBuilder.php
+++ b/src/Client/AkeneoPimClientBuilder.php
@@ -145,7 +145,6 @@ class AkeneoPimClientBuilder
             $authenticatedHttpClient,
             $uriGenerator,
             $multipartStreamBuilderFactory,
-            $this->getStreamFactory(),
             $upsertListResponseFactory
         );
 

--- a/src/Client/ResourceClientInterface.php
+++ b/src/Client/ResourceClientInterface.php
@@ -88,9 +88,10 @@ interface ResourceClientInterface
     /**
      * Updates or creates several resources.
      *
-     * @param string             $uri           URI of the resource
-     * @param array              $uriParameters URI parameters of the resource
-     * @param array|\Traversable $resources     array of resources to create or update
+     * @param string                $uri           URI of the resource
+     * @param array                 $uriParameters URI parameters of the resource
+     * @param array|StreamInterface $resources     array of resources to create or update.
+     *                                             You can pass your own StreamInterface implementation as well.
      *
      * @throws HttpException
      *

--- a/tests/Api/ApiTestCase.php
+++ b/tests/Api/ApiTestCase.php
@@ -4,12 +4,12 @@ namespace Akeneo\Pim\tests\Api;
 
 use Akeneo\Pim\Client\AkeneoPimClientBuilder;
 use Akeneo\Pim\Client\AkeneoPimClientInterface;
-use Akeneo\Pim\Routing\UriGenerator;
-use Akeneo\Pim\Routing\UriGeneratorInterface;
 use Akeneo\Pim\tests\DockerCredentialGenerator;
 use Akeneo\Pim\tests\DockerDatabaseInstaller;
 use Akeneo\Pim\tests\LocalCredentialGenerator;
 use Akeneo\Pim\tests\LocalDatabaseInstaller;
+use Http\Discovery\StreamFactoryDiscovery;
+use Http\Message\StreamFactory;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -71,6 +71,14 @@ abstract class ApiTestCase extends \PHPUnit_Framework_TestCase
         $config = Yaml::parse(file_get_contents($configFile));
 
         return $config;
+    }
+
+    /**
+     * @return StreamFactory
+     */
+    public function getStreamFactory()
+    {
+        return StreamFactoryDiscovery::find();
     }
 
     /**

--- a/tests/Api/Category/UpsertListCategoryIntegration.php
+++ b/tests/Api/Category/UpsertListCategoryIntegration.php
@@ -6,7 +6,7 @@ use Akeneo\Pim\tests\Api\ApiTestCase;
 
 class UpsertListCategoryIntegration extends ApiTestCase
 {
-    public function testUpsertListSuccessful()
+    public function testUpsertListFromArraySuccessful()
     {
         $api = $this->createClient()->getCategoryApi();
 
@@ -32,19 +32,52 @@ class UpsertListCategoryIntegration extends ApiTestCase
         $this->assertInstanceOf('\Iterator', $response);
 
         $responseLines = iterator_to_array($response);
-        $this->assertCount(2, $responseLines);
 
         $this->assertSame([
-            'line'        => 1,
-            'code'        => 'sandals',
-            'status_code' => 204,
-        ], $responseLines[1]);
+            1 => [
+                'line'        => 1,
+                'code'        => 'sandals',
+                'status_code' => 204,
+            ],
+            2 => [
+                'line'        => 2,
+                'code'        => 'booties',
+                'status_code' => 201,
+            ]
+        ], $responseLines);
+    }
+
+    public function testUpsertListFromStreamSuccessful()
+    {
+        $resourcesContent =
+<<<JSON
+{"code":"sandals","parent":"winter_collection","labels":{"en_US":"Sandals","fr_FR":"Sandales"}}
+{"code":"booties","parent":"summer_collection","labels":{"en_US":"Booties","fr_FR":"Bottines"}}
+JSON;
+        $resources = fopen('php://memory', 'w+');
+        fwrite($resources, $resourcesContent);
+        rewind($resources);
+
+        $streamedResources = $this->getStreamFactory()->createStream($resources);
+        $api = $this->createClient()->getCategoryApi();
+        $response = $api->upsertList($streamedResources);
+
+        $this->assertInstanceOf('\Iterator', $response);
+
+        $responseLines = iterator_to_array($response);
 
         $this->assertSame([
-            'line'        => 2,
-            'code'        => 'booties',
-            'status_code' => 201,
-        ], $responseLines[2]);
+            1 => [
+                'line'        => 1,
+                'code'        => 'sandals',
+                'status_code' => 204,
+            ],
+            2 => [
+                'line'        => 2,
+                'code'        => 'booties',
+                'status_code' => 201,
+            ]
+        ], $responseLines);
     }
 
     public function testUpsertListFailed()
@@ -72,18 +105,18 @@ class UpsertListCategoryIntegration extends ApiTestCase
         $this->assertInstanceOf('\Iterator', $response);
 
         $responseLines = iterator_to_array($response);
-        $this->assertCount(2, $responseLines);
 
         $this->assertSame([
-            'line'        => 1,
-            'status_code' => 422,
-            'message'     => 'Code is missing.',
-        ], $responseLines[1]);
-
-        $this->assertSame([
-            'line'        => 2,
-            'status_code' => 413,
-            'message' => 'Line is too long.',
-        ], $responseLines[2]);
+            1 => [
+                'line'        => 1,
+                'status_code' => 422,
+                'message'     => 'Code is missing.',
+            ],
+            2 => [
+                'line'        => 2,
+                'status_code' => 413,
+                'message'     => 'Line is too long.',
+            ]
+        ], $responseLines);
     }
 }


### PR DESCRIPTION
I have added an integration test only for one entity for the moment (Category). I will add another for Product but that's all. The goal is to test that the "upsert list" works with a stream as parameter, not that the server API response well (it's done in tests with arrays). So to repeat this test for every entity would be too much.